### PR TITLE
Added Dynamic copyright_year to auto fetch the current year

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -5,6 +5,8 @@ import { useRouter } from "next/navigation";
 import "./footer.css";
 
 const Footer = () => {
+  const today = new Date();
+  const year = today.getFullYear();
   const router = useRouter();
   const handleAbout = () => {
     router.push(`/aboutus`);
@@ -32,7 +34,8 @@ const Footer = () => {
       </div>
       <div className="text-center">
         <p className=" text-[14px] text-slate-300/80">
-          Copyright &copy; By Clippy
+          Copyright &copy; {year} By Clippy
+        <p className="text-lg"></p>
         </p>
         <p className="text-[10px] text-slate-300/80">All rights reserved</p>
       </div>


### PR DESCRIPTION
# Pull Request

### Title
<!-- Provide a clear and concise title for the pull request -->

### Description
<!-- Brief summary of the changes made and the purpose of the PR -->

---

### Description:
This PR enhances the footer section of the website by adding the current copyright year, which is fetched dynamically. This ensures that the copyright year will always be up-to-date without requiring manual updates each year.

#### Changes:
1. **Footer HTML**: Updated the footer to include a placeholder for the copyright year.
2. **JavaScript**: Added a script to fetch the current year dynamically and insert it into the footer.
3. **CSS**: Ensured that the styling of the footer remains consistent with the new dynamic content.
]

### Related Issues
<!-- Mention any related issue numbers (e.g., "Fixes #123") -->
fixes #90 

### Changes Made
<!-- List of changes made in the PR (e.g., new features, bug fixes, improvements) -->
feature + bug 

### Checklist 
<!-- 
This is how you check the check boxes where ever there is "[ ]" change it to [x]
- [ ] Unchecked box
- [x] Checked box
 -->
- [X] I have tested the changes locally
- [ ] Documentation has been updated (if necessary)
- [ ] Changes are backward-compatible

### Screenshots (if applicable)
<!-- Add any relevant screenshots to illustrate the changes -->
![clippy](https://github.com/user-attachments/assets/43c5d133-6126-4d6c-86f6-cd064390ff84)

### Additional Notes
<!-- Any additional information that might be helpful for the reviewer -->